### PR TITLE
Fix for #2: Store http.Request reference in endpoints.Context

### DIFF
--- a/endpoints/auth.go
+++ b/endpoints/auth.go
@@ -68,6 +68,9 @@ var (
 type Context interface {
 	appengine.Context
 
+	// HttpRequest returns the request associated with this context.	
+	HttpRequest() *http.Request
+
 	// CurrentOAuthClientID returns a clientId associated with the scope.
 	CurrentOAuthClientID(scope string) (string, error)
 
@@ -518,12 +521,7 @@ func CurrentUser(c Context, scopes []string, audiences []string, clientIDs []str
 		return nil, errors.New("No client ID or scope info provided.")
 	}
 
-	req, ok := c.Request().(*http.Request)
-	if !ok {
-		return nil, errors.New("No request exists in the context.")
-	}
-
-	token := getToken(req)
+	token := getToken(c.HttpRequest())
 	if token == "" {
 		return nil, errors.New("No token in the current context.")
 	}

--- a/endpoints/context.go
+++ b/endpoints/context.go
@@ -32,6 +32,7 @@ import (
 
 type cachingContext struct {
 	appengine.Context
+	r *http.Request
 	// map keys are scopes
 	oauthResponseCache map[string]*pb.GetOAuthUserResponse
 	// mutex for oauthResponseCache
@@ -71,6 +72,11 @@ func getOAuthResponse(c *cachingContext, scope string) (*pb.GetOAuthUserResponse
 	return res, nil
 }
 
+// HttpRequest returns the request associated with this context.	
+func (c *cachingContext) HttpRequest() *http.Request {
+	return c.r
+}
+
 // CurrentOAuthClientID returns a clientId associated with the scope.
 func (c *cachingContext) CurrentOAuthClientID(scope string) (string, error) {
 	res, err := getOAuthResponse(c, scope)
@@ -105,7 +111,7 @@ func cachingContextFactory(r *http.Request) Context {
 	// then there's nothing else to do here.
 	// (was: Fail if ctx is nil.)
 	ac := appengine.NewContext(r)
-	return &cachingContext{ac, map[string]*pb.GetOAuthUserResponse{}, sync.Mutex{}}
+	return &cachingContext{ac, r, map[string]*pb.GetOAuthUserResponse{}, sync.Mutex{}}
 }
 
 func init() {


### PR DESCRIPTION
This change would just keep a reference to http.Request and use that instead of interfering with internal workings of `appengine.Context.Request()`.

So, instead of this:

``` go
req, ok := c.Request().(*http.Request)
if !ok {
  // always fails on production
}
```

we can now just do

``` go
req := c.HttpRequest()
// go ahead and use req, no even need for a type assertion
```

(a possible solution for https://github.com/crhym3/go-endpoints/issues/2#issuecomment-18984862)
