### PR TITLE
Formatting problem in endpoints/errors

### DIFF
--- a/endpoints/errors.go
+++ b/endpoints/errors.go
@@ -110,6 +110,8 @@ func newErrorResponse(e error) *errorResponse {
 		if strings.HasPrefix(msg, name) {
 			err.Name = name
 			err.Msg = msg[len(name):]
+			err.Msg = strings.TrimPrefix(err.Msg, ":")
+			err.Msg = strings.TrimSpace(err.Msg)
 			err.Code = errorCodes[i]
 		}
 	}


### PR DESCRIPTION
`err = endpoints.NewNotFoundError("test msg")`

outputs: 

```
"message": "user was not found.",
```

However,

`err = fmt.Errorf("Not Found: test msg")`

outputs

`"message": ": test",`

I would expect both to be equivalent.
