### PR TITLE
New service method specs

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,26 +51,22 @@ type GreetingService struct {
 
 // List responds with a list of all greetings ordered by Date field.
 // Most recent greets come first.
-func (gs *GreetingService) List(
-  r *http.Request, req *GreetingsListReq, resp *GreetingsList) error {
-
-  if req.Limit <= 0 {
-    req.Limit = 10
+func (gs *GreetingService) List(c endpoints.Context, r *GreetingsListReq) (*GreetingsList, error) {
+  if r.Limit <= 0 {
+    r.Limit = 10
   }
 
-  c := endpoints.NewContext(r)
-  q := datastore.NewQuery("Greeting").Order("-Date").Limit(req.Limit)
-  greets := make([]*Greeting, 0, req.Limit)
+  q := datastore.NewQuery("Greeting").Order("-Date").Limit(r.Limit)
+  greets := make([]*Greeting, 0, r.Limit)
   keys, err := q.GetAll(c, &greets)
   if err != nil {
-    return err
+    return nil, err
   }
 
   for i, k := range keys {
     greets[i].Key = k
   }
-  resp.Items = greets
-  return nil
+  return &GreetingsList{greets}, nil
 }
 ```
 

--- a/endpoints/server.go
+++ b/endpoints/server.go
@@ -47,10 +47,14 @@ func NewServer(root string) *Server {
 //    - The receiver is exported (begins with an upper case letter) or local
 //      (defined in the package registering the service).
 //    - The method name is exported.
-//    - The method has three arguments: *http.Request, *args, *reply.
-//    - All three arguments are pointers.
-//    - The second and third arguments are exported or local.
-//    - The method has return type error.
+//    - The method has either 2 arguments and 2 return values:
+//      *http.Request|Context, *arg => *reply, error
+//      or 3 arguments and 1 return value:
+//      *http.Request|Context, *arg, *reply => error
+//    - The first argument is either *http.Request or Context.
+//    - Second argument (*arg) and *reply are exported or local.
+//    - First argument, *arg and *reply are all pointers.
+//    - First (or second, if method has 2 arguments) return value is of type error.
 //
 // All other methods are ignored.
 func (s *Server) RegisterService(srv interface{}, name, ver, desc string, isDefault bool) (*RPCService, error) {
@@ -113,7 +117,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Initialize RPC method request
-	req := reflect.New(methodSpec.ReqType)
+	reqValue := reflect.New(methodSpec.ReqType)
 
 	body, err := ioutil.ReadAll(r.Body)
 	if err != nil {
@@ -126,28 +130,42 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	// 	writeError(w, fmt.Errorf("Error while decoding JSON: %q", err))
 	// 	return
 	// }
-	if err := json.Unmarshal(body, req.Interface()); err != nil {
+	if err := json.Unmarshal(body, reqValue.Interface()); err != nil {
 		writeError(w, err)
 		return
 	}
 
-	// Initialize RPC method response and call method's function
-	resp := reflect.New(methodSpec.RespType)
-	errValue := methodSpec.method.Func.Call([]reflect.Value{
-		serviceSpec.rcvr,
-		reflect.ValueOf(r),
-		req,
-		resp,
-	})
+	// Construct arguments for the method call
+	var httpReqOrCtx interface{} = r
+	if methodSpec.wantsContext {
+		httpReqOrCtx = c
+	}
+	args := []reflect.Value{serviceSpec.rcvr, reflect.ValueOf(httpReqOrCtx), reqValue}
+
+	var respValue reflect.Value
+	if !methodSpec.returnsResp {
+		respValue = reflect.New(methodSpec.RespType)
+		args = append(args, respValue)
+	}
+
+	// Invoke the service method
+	var errValue reflect.Value
+	res := methodSpec.method.Func.Call(args)
+	if methodSpec.returnsResp {
+		respValue = res[0]
+		errValue = res[1]
+	} else {
+		errValue = res[0]
+	}
 
 	// Check if method returned an error
-	if err := errValue[0].Interface(); err != nil {
+	if err := errValue.Interface(); err != nil {
 		writeError(w, err.(error))
 		return
 	}
 
 	// Encode non-error response
-	if err := json.NewEncoder(w).Encode(resp.Interface()); err != nil {
+	if err := json.NewEncoder(w).Encode(respValue.Interface()); err != nil {
 		writeError(w, err)
 	}
 }

--- a/endpoints/server_test.go
+++ b/endpoints/server_test.go
@@ -14,7 +14,7 @@ import (
 	"appengine/aetest"
 )
 
-type msg struct {
+type TestMsg struct {
 	Name string `json:"name"`
 }
 
@@ -28,65 +28,100 @@ func (s *ServerTestService) Error(r *http.Request, _, _ *VoidMessage) error {
 	return errors.New("Dummy error")
 }
 
-func (s *ServerTestService) Msg(r *http.Request, req, resp *msg) error {
+func (s *ServerTestService) Msg(r *http.Request, req, resp *TestMsg) error {
 	resp.Name = req.Name
 	return nil
 }
 
-func (s *ServerTestService) CustomAPIError(r *http.Request, req, resp *msg) error {
+func (s *ServerTestService) CustomAPIError(r *http.Request, req, resp *TestMsg) error {
 	return NewAPIError("MethodNotAllowed", "MethodNotAllowed", http.StatusMethodNotAllowed)
 }
 
-func (s *ServerTestService) InternalServer(r *http.Request, req, resp *msg) error {
+func (s *ServerTestService) InternalServer(r *http.Request, req, resp *TestMsg) error {
 	return InternalServerError
 }
 
-func (s *ServerTestService) BadRequest(r *http.Request, req, resp *msg) error {
+func (s *ServerTestService) BadRequest(r *http.Request, req, resp *TestMsg) error {
 	return BadRequestError
 }
 
-func (s *ServerTestService) NotFound(r *http.Request, req, resp *msg) error {
+func (s *ServerTestService) NotFound(r *http.Request, req, resp *TestMsg) error {
 	return NotFoundError
 }
 
-func (s *ServerTestService) Forbidden(r *http.Request, req, resp *msg) error {
+func (s *ServerTestService) Forbidden(r *http.Request, req, resp *TestMsg) error {
 	return ForbiddenError
 }
 
-func (s *ServerTestService) Unauthorized(r *http.Request, req, resp *msg) error {
+func (s *ServerTestService) Unauthorized(r *http.Request, req, resp *TestMsg) error {
 	return UnauthorizedError
 }
 
-func (s *ServerTestService) Conflict(r *http.Request, req, resp *msg) error {
+func (s *ServerTestService) Conflict(r *http.Request, req, resp *TestMsg) error {
 	return ConflictError
 }
 
+// Service methods for args testing
+
+func (s *ServerTestService) MsgWithRequest(r *http.Request, req, resp *TestMsg) error {
+	if r == nil {
+		return errors.New("MsgWithRequest: r = nil")
+	}
+	resp.Name = req.Name
+	return nil
+}
+
+func (s *ServerTestService) MsgWithContext(c Context, req, resp *TestMsg) error {
+	if c == nil {
+		return errors.New("MsgWithContext: c = nil")
+	}
+	resp.Name = req.Name
+	return nil
+}
+
+func (s *ServerTestService) MsgWithReturn(c Context, req *TestMsg) (*TestMsg, error) {
+	if c == nil {
+		return nil, errors.New("MsgReturnResp: c = nil")
+	}
+	return &TestMsg{req.Name}, nil
+}
+
+func createAPIServer() *Server {
+	s := &ServerTestService{}
+	rpc := &RPCService{
+		name:     "ServerTestService",
+		rcvr:     reflect.ValueOf(s),
+		rcvrType: reflect.TypeOf(s),
+		methods:  make(map[string]*ServiceMethod),
+	}
+	for i := 0; i < rpc.rcvrType.NumMethod(); i++ {
+		m := rpc.rcvrType.Method(i)
+		sm := &ServiceMethod{
+			method:       &m,
+			wantsContext: m.Type.In(1).Implements(typeOfContext),
+			ReqType:      m.Type.In(2).Elem(),
+		}
+		if m.Type.NumOut() == 2 {
+			sm.returnsResp = true
+			sm.RespType = m.Type.Out(0).Elem()
+		} else {
+			sm.RespType = m.Type.In(3).Elem()
+		}
+		rpc.methods[m.Name] = sm
+	}
+
+	smap := &serviceMap{services: make(map[string]*RPCService)}
+	smap.services[rpc.name] = rpc
+	return &Server{root: "/_ah/spi", services: smap}
+}
+
 func TestServerServeHTTP(t *testing.T) {
+	server := createAPIServer()
 	inst, err := aetest.NewInstance(nil)
 	if err != nil {
 		t.Fatalf("failed to create instance: %v", err)
 	}
 	defer inst.Close()
-
-	myService := &ServerTestService{}
-	rpc := &RPCService{
-		name:     "ServerTestService",
-		rcvr:     reflect.ValueOf(myService),
-		rcvrType: reflect.TypeOf(myService),
-		methods:  make(map[string]*ServiceMethod),
-	}
-	for i := 0; i < rpc.rcvrType.NumMethod(); i++ {
-		meth := rpc.rcvrType.Method(i)
-		rpc.methods[meth.Name] = &ServiceMethod{
-			method:   &meth,
-			ReqType:  meth.Type.In(2).Elem(),
-			RespType: meth.Type.In(3).Elem(),
-		}
-	}
-
-	srvMap := &serviceMap{services: make(map[string]*RPCService)}
-	srvMap.services[rpc.name] = rpc
-	server := &Server{root: "/_ah/spi", services: srvMap}
 
 	tts := []struct {
 		httpVerb           string
@@ -115,7 +150,7 @@ func TestServerServeHTTP(t *testing.T) {
 	}
 
 	for i, tt := range tts {
-		path := "/" + rpc.name + "." + tt.srvMethod
+		path := "/ServerTestService." + tt.srvMethod
 		var body io.Reader
 		if tt.httpVerb == "POST" || tt.httpVerb == "PUT" {
 			body = strings.NewReader(tt.in)
@@ -143,6 +178,74 @@ func TestServerServeHTTP(t *testing.T) {
 		if w.Code != tt.code {
 			t.Errorf("%d: %s %s w.Code = %d; want %d",
 				i, tt.httpVerb, path, w.Code, tt.code)
+		}
+	}
+}
+
+func TestServerMethodCall(t *testing.T) {
+	server := createAPIServer()
+	inst, err := aetest.NewInstance(nil)
+	if err != nil {
+		t.Fatalf("failed to create instance: %v", err)
+	}
+	defer inst.Close()
+
+	tts := []struct {
+		name, body string
+	}{
+		{"MsgWithRequest", `{"name":"request"}`},
+		{"MsgWithContext", `{"name":"context"}`},
+		{"MsgWithReturn", `{"name":"return"}`},
+	}
+
+	for i, tt := range tts {
+		path := "/ServerTestService." + tt.name
+		body := strings.NewReader(tt.body)
+		r, err := inst.NewRequest("POST", path, body)
+		if err != nil {
+			t.Fatalf("%d: failed to create req: %v", t, err)
+		}
+
+		w := httptest.NewRecorder()
+		server.ServeHTTP(w, r)
+
+		res := strings.TrimSpace(w.Body.String())
+		if res != tt.body {
+			t.Errorf("%d: %s res = %q; want %q", i, tt.name, res, tt.body)
+		}
+		if w.Code != http.StatusOK {
+			t.Errorf("%d: %s code = %d; want %d", i, tt.name, w.Code, http.StatusOK)
+		}
+	}
+}
+
+func TestServerRegisterService(t *testing.T) {
+	s, err := NewServer("").
+		RegisterService(&ServerTestService{}, "ServerTestService", "v1", "", true)
+	if err != nil {
+		t.Fatalf("error registering service: %v", err)
+	}
+
+	tts := []struct {
+		name         string
+		wantsContext bool
+		returnsResp  bool
+	}{
+		{"MsgWithRequest", false, false},
+		{"MsgWithContext", true, false},
+		{"MsgWithReturn", true, true},
+	}
+	for i, tt := range tts {
+		m := s.MethodByName(tt.name)
+		if m == nil {
+			t.Errorf("%d: MethodByName(%q) = nil", i, tt.name)
+			continue
+		}
+		if m.wantsContext != tt.wantsContext {
+			t.Errorf("%d: wantsContext = %v; want %v", i, m.wantsContext, tt.wantsContext)
+		}
+		if m.returnsResp != tt.returnsResp {
+			t.Errorf("%d: returnsResp = %v; want %v", i, m.returnsResp, tt.returnsResp)
 		}
 	}
 }


### PR DESCRIPTION
Implementation for #45:

```go
// Different first arg
func (Service) SayHello(c endpoints.Context, req *Request, res *Response) error {}
// Response is created within the method and returned as the first value
func (Service) SayHello(c endpoints.Context, req *Request) (*Response, error) {}
```

The old method spec is kept for compatibility:
```go
func (Service) SayHello(r *http.Request, req *Request, res *Response) error {}
```

@campoy I'd be happy if you reviewed this change.