### PR TITLE
restore body of requests before calling handlers

### DIFF
--- a/endpoints/server.go
+++ b/endpoints/server.go
@@ -6,6 +6,7 @@
 package endpoints
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
 	"net/http"
@@ -118,6 +119,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	reqValue := reflect.New(methodSpec.ReqType)
 
 	body, err := ioutil.ReadAll(r.Body)
+	r.Body.Close()
 	if err != nil {
 		writeError(w, err)
 		return
@@ -132,6 +134,9 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		writeError(w, err)
 		return
 	}
+
+	// Restore the body in the original request.
+	r.Body = ioutil.NopCloser(bytes.NewReader(body))
 
 	numIn, numOut := methodSpec.method.Type.NumIn(), methodSpec.method.Type.NumOut()
 	// Construct arguments for the method call

--- a/endpoints/server_test.go
+++ b/endpoints/server_test.go
@@ -1,8 +1,10 @@
 package endpoints
 
 import (
+	"encoding/json"
 	"errors"
 	"io"
+	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
 	"reflect"
@@ -14,6 +16,10 @@ import (
 
 type TestMsg struct {
 	Name string `json:"name"`
+}
+
+type BytesMsg struct {
+	Bytes []byte
 }
 
 type ServerTestService struct{}
@@ -103,6 +109,15 @@ func (s *ServerTestService) MsgWithoutRequestNorResponse(c Context) error {
 		return errors.New("MsgWithoutRequestNorResponse: c = nil")
 	}
 	return nil
+}
+
+func (s *ServerTestService) EchoRequest(r *http.Request, req *TestMsg) (*BytesMsg, error) {
+	b, err := ioutil.ReadAll(r.Body)
+	r.Body.Close()
+	if err != nil {
+		return nil, err
+	}
+	return &BytesMsg{b}, nil
 }
 
 func createAPIServer() *Server {
@@ -264,5 +279,33 @@ func TestServerRegisterService(t *testing.T) {
 		if m.wantsContext != tt.wantsContext {
 			t.Errorf("%d: wantsContext = %v; want %v", i, m.wantsContext, tt.wantsContext)
 		}
+	}
+}
+
+func TestServerRequestNotEmpty(t *testing.T) {
+	server := createAPIServer()
+	inst, err := aetest.NewInstance(nil)
+	if err != nil {
+		t.Fatalf("failed to create instance: %v", err)
+	}
+	defer inst.Close()
+
+	path := "/ServerTestService.EchoRequest"
+	body := `{"name": "francesc"}`
+	r, err := inst.NewRequest("POST", path, strings.NewReader(body))
+	if err != nil {
+		t.Fatalf("failed to create req: %v", err)
+	}
+
+	w := httptest.NewRecorder()
+	server.ServeHTTP(w, r)
+
+	var res BytesMsg
+	if err := json.NewDecoder(w.Body).Decode(&res); err != nil {
+		t.Fatalf("decode response %q: %v", w.Body.String(), err)
+	}
+
+	if string(res.Bytes) != body {
+		t.Fatalf("expected %q; got %q", body, res)
 	}
 }


### PR DESCRIPTION
Decoding the request message from the http.Request was consuming the request's body.
Creating a new ReadCloser makes this transparent to users' code.

Fixes: https://github.com/GoogleCloudPlatform/go-endpoints/issues/71

