### PR TITLE
Allow third party auth provider

### DIFF
--- a/endpoints/auth.go
+++ b/endpoints/auth.go
@@ -22,7 +22,10 @@ import (
 	"google.golang.org/appengine/user"
 )
 
-const APIExplorerClientID = "292824132082.apps.googleusercontent.com"
+const (
+	APIExplorerClientID = "292824132082.apps.googleusercontent.com"
+	EmailScope          = "https://www.googleapis.com/auth/userinfo.email"
+)
 
 var AuthProvider = &AuthProviderConfig{
 	IssuerID: "accounts.google.com",
@@ -30,7 +33,7 @@ var AuthProvider = &AuthProviderConfig{
 		"v1/metadata/raw/federated-signon@system.gserviceaccount.com",
 	UserInfoEndpoint: "https://www.googleapis.com/oauth2/v1/tokeninfo",
 	ScopesSupported: []string{
-		"https://www.googleapis.com/auth/userinfo.email",
+		EmailScope,
 		"openid",
 		"email",
 		"profile",

--- a/endpoints/auth.go
+++ b/endpoints/auth.go
@@ -22,17 +22,36 @@ import (
 	"google.golang.org/appengine/user"
 )
 
-const (
-	// DefaultCertURI is Google's public URL which points to JWT certs.
-	DefaultCertURI = ("https://www.googleapis.com/service_accounts/" +
-		"v1/metadata/raw/federated-signon@system.gserviceaccount.com")
-	// EmailScope is Google's OAuth 2.0 email scope
-	EmailScope = "https://www.googleapis.com/auth/userinfo.email"
-	// TokeninfoURL is Google's OAuth 2.0 access token verification URL
-	TokeninfoURL = "https://www.googleapis.com/oauth2/v1/tokeninfo"
-	// APIExplorerClientID is the client ID of API explorer.
-	APIExplorerClientID = "292824132082.apps.googleusercontent.com"
-)
+const APIExplorerClientID = "292824132082.apps.googleusercontent.com"
+
+var AuthProvider = &AuthProviderConfig{
+	IssuerID: "accounts.google.com",
+	JWKSURI: "https://www.googleapis.com/service_accounts/" +
+		"v1/metadata/raw/federated-signon@system.gserviceaccount.com",
+	UserInfoEndpoint: "https://www.googleapis.com/oauth2/v1/tokeninfo",
+	ScopesSupported: []string{
+		"https://www.googleapis.com/auth/userinfo.email",
+		"openid",
+		"email",
+		"profile",
+	},
+}
+
+// AuthProvider describes an OpenID provider.
+type AuthProviderConfig struct {
+	// IssuerID is verifiable identifier for an issuer. An Issuer Identifier
+	// is a case-sensitive URL using the https scheme that contains scheme,
+	// host, and optionally, port number and path components and no query
+	// or fragment components. Note that Google only uses a hostname.
+	IssuerID string
+	// URL of the OP's JSON Web Key Set.
+	JWKSURI string
+	// UserInfoEndpoint is the URL of the OP's UserInfo Endpoint.
+	UserInfoEndpoint string
+	// ScopesSupported contains a list of the OAuth 2.0 scope values that are
+	// supported by this provider.
+	ScopesSupported []string
+}
 
 var (
 	allowedAuthSchemesUpper = [2]string{"OAUTH", "BEARER"}
@@ -196,7 +215,7 @@ func cachedCerts(c context.Context) (*certsList, error) {
 
 	var certs *certsList
 
-	_, err = memcache.JSON.Get(namespacedContext, DefaultCertURI, &certs)
+	_, err = memcache.JSON.Get(namespacedContext, AuthProvider.JWKSURI, &certs)
 	if err == nil {
 		return certs, nil
 	}
@@ -209,8 +228,8 @@ func cachedCerts(c context.Context) (*certsList, error) {
 		log.Debugf(c, "%s", err.Error())
 	}
 
-	log.Debugf(c, "Fetching provider certs from: %s", DefaultCertURI)
-	resp, err := newHTTPClient(c).Get(DefaultCertURI)
+	log.Debugf(c, "Fetching provider certs from: %s", AuthProvider.JWKSURI)
+	resp, err := newHTTPClient(c).Get(AuthProvider.JWKSURI)
 	if err != nil {
 		return nil, err
 	}
@@ -232,7 +251,7 @@ func cachedCerts(c context.Context) (*certsList, error) {
 		expiration := certExpirationTime(resp.Header)
 		if expiration > 0 {
 			item := &memcache.Item{
-				Key:        DefaultCertURI,
+				Key:        AuthProvider.JWKSURI,
 				Value:      certBytes,
 				Expiration: expiration,
 			}
@@ -422,7 +441,7 @@ func verifySignedJWT(c context.Context, jwt string, now int64) (*signedJWT, erro
 // by audiences and clientIDs args.
 func verifyParsedToken(c context.Context, token signedJWT, audiences []string, clientIDs []string) bool {
 	// Verify the issuer.
-	if token.Issuer != "accounts.google.com" {
+	if token.Issuer != AuthProvider.IssuerID {
 		log.Warningf(c, "Issuer was not valid: %s", token.Issuer)
 		return false
 	}
@@ -455,10 +474,11 @@ func verifyParsedToken(c context.Context, token signedJWT, audiences []string, c
 		return false
 	}
 
-	if token.Email == "" {
-		log.Warningf(c, "Invalid email value in token")
-		return false
-	}
+	// Some auth provider do not disclose this
+	// if token.Email == "" {
+	// 	log.Warningf(c, "Invalid email value in token")
+	// 	return false
+	// }
 
 	return true
 }
@@ -560,18 +580,14 @@ func CurrentUser(c context.Context, scopes []string, audiences []string, clientI
 		return nil, errors.New("No token in the current context.")
 	}
 
-	// If the only scope is the email scope, check an ID token. Alternatively,
-	// we dould check if token starts with "ya29." or "1/" to decide that it
-	// is a Bearer token. This is what is done in Java.
-	if len(scopes) == 1 && scopes[0] == EmailScope && len(clientIDs) > 0 {
-		log.Debugf(c, "Checking for ID token.")
-		now := currentUTC().Unix()
-		u, err := currentIDTokenUser(c, token, audiences, clientIDs, now)
-		// Only return in case of success, else pass along and try
-		// parsing Bearer token.
-		if err == nil {
-			return u, err
-		}
+	// If the token isn't valid currentIDTokenUser will fail right away
+	log.Debugf(c, "Checking for ID token.")
+	now := currentUTC().Unix()
+	u, err := currentIDTokenUser(c, token, audiences, clientIDs, now)
+	// Only return in case of success, else pass along and try
+	// parsing Bearer token.
+	if err == nil {
+		return u, err
 	}
 
 	log.Debugf(c, "Checking for Bearer token.")

--- a/endpoints/auth_test.go
+++ b/endpoints/auth_test.go
@@ -182,7 +182,7 @@ func TestCachedCertsCacheHit(t *testing.T) {
 	}
 	ec := NewContext(req)
 	for i, tt := range tts {
-		item := &memcache.Item{Key: DefaultCertURI, Value: []byte(tt.cacheValue)}
+		item := &memcache.Item{Key: AuthProvider.JWKSURI, Value: []byte(tt.cacheValue)}
 		if err := memcache.Set(nc, item); err != nil {
 			t.Fatal(err)
 		}
@@ -239,7 +239,7 @@ func TestCachedCertsCacheMiss(t *testing.T) {
 			resp.Header.Set("age", tt.age)
 			rt.Add(resp)
 		}
-		memcache.Delete(nc, DefaultCertURI)
+		memcache.Delete(nc, AuthProvider.JWKSURI)
 
 		out, err := cachedCerts(ec)
 		switch {
@@ -254,15 +254,15 @@ func TestCachedCertsCacheMiss(t *testing.T) {
 			if !tt.shouldCache {
 				continue
 			}
-			item, err := memcache.Get(nc, DefaultCertURI)
+			item, err := memcache.Get(nc, AuthProvider.JWKSURI)
 			if err != nil {
-				t.Errorf("%d: memcache.Get(%q) = %v", i, DefaultCertURI, err)
+				t.Errorf("%d: memcache.Get(%q) = %v", i, AuthProvider.JWKSURI, err)
 				continue
 			}
 			cert := string(item.Value)
 			if tt.respContent != cert {
 				t.Errorf("%d: memcache.Get(%q) = %q; want %q",
-					i, DefaultCertURI, cert, tt.respContent)
+					i, AuthProvider.JWKSURI, cert, tt.respContent)
 			}
 		}
 	}
@@ -365,7 +365,7 @@ func TestCurrentUser(t *testing.T) {
 		t.Fatal(err)
 	}
 	// googCerts are provided in jwt_test.go
-	item := &memcache.Item{Key: DefaultCertURI, Value: []byte(googCerts)}
+	item := &memcache.Item{Key: AuthProvider.JWKSURI, Value: []byte(googCerts)}
 	if err := memcache.Set(nc, item); err != nil {
 		t.Fatal(err)
 	}

--- a/endpoints/jwt_test.go
+++ b/endpoints/jwt_test.go
@@ -121,7 +121,7 @@ func TestVerifySignedJWT(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	item := &memcache.Item{Key: DefaultCertURI, Value: []byte(googCerts)}
+	item := &memcache.Item{Key: AuthProvider.JWKSURI, Value: []byte(googCerts)}
 	if err := memcache.Set(nc, item); err != nil {
 		t.Fatal(err)
 	}
@@ -177,7 +177,7 @@ func TestVerifyParsedToken(t *testing.T) {
 		{goog, "hello-android", clientID, email, true},
 		{goog, "invalid", clientID, email, false},
 		{goog, clientID, "invalid", email, false},
-		{goog, clientID, clientID, "", false},
+		// {goog, clientID, clientID, "", false},
 		{"", clientID, clientID, email, false},
 	}
 


### PR DESCRIPTION
Example use :

``` go
var myProvider = &endpoints.AuthProviderConfig{
    IssuerID: "https://example.com",
    JWKSURI: "https://www.googleapis.com/service_accounts" +
        "/v1/metadata/raw/APPID@appspot.gserviceaccount.com",
    UserInfoEndpoint: "https://example.com/oauth2/v1/tokeninfo",
    ScopesSupported: []string{
        "openid",
        "email",
        "profile",
    },
}

func init() {
    endpoints.AuthProvider = myProvider
}
```
