### PR TITLE
Enable optional per-method Context callback.

### DIFF
--- a/endpoints/auth.go
+++ b/endpoints/auth.go
@@ -81,11 +81,27 @@ const (
 	invalidKey contextKey = iota
 	requestKey
 	authenticatorKey
+	serviceInfoKey
+	methodInfoKey
 )
 
 // HTTPRequest returns the request associated with a context.
 func HTTPRequest(c context.Context) *http.Request {
 	r, _ := c.Value(requestKey).(*http.Request)
+	return r
+}
+
+// GetServiceInfo returns the ServiceInfo of the service that the current
+// request is using. This may only be used on Context's created with NewContext.
+func GetServiceInfo(c context.Context) *ServiceInfo {
+	r, _ := c.Value(serviceInfoKey).(*ServiceInfo)
+	return r
+}
+
+// GetMethodInfo returns the MethodInfo of the method that the current
+// request is using. This may only be used on Context's created with NewContext.
+func GetMethodInfo(c context.Context) *MethodInfo {
+	r, _ := c.Value(methodInfoKey).(*MethodInfo)
 	return r
 }
 
@@ -103,10 +119,12 @@ var (
 )
 
 // NewContext returns a new context for an in-flight API (HTTP) request.
-func NewContext(r *http.Request) context.Context {
+func NewContext(r *http.Request, si *ServiceInfo, mi *MethodInfo) context.Context {
 	c := appengine.NewContext(r)
 	c = context.WithValue(c, requestKey, r)
 	c = context.WithValue(c, authenticatorKey, AuthenticatorFactory())
+	c = context.WithValue(c, serviceInfoKey, si)
+	c = context.WithValue(c, methodInfoKey, mi)
 	return c
 }
 

--- a/endpoints/auth_test.go
+++ b/endpoints/auth_test.go
@@ -180,7 +180,7 @@ func TestCachedCertsCacheHit(t *testing.T) {
 	    	 "modulus": "123"} ]}`,
 			&certsList{[]*certInfo{{"RS256", "123", "some-id", "123"}}}},
 	}
-	ec := NewContext(req)
+	ec := NewContext(req, nil, nil)
 	for i, tt := range tts {
 		item := &memcache.Item{Key: DefaultCertURI, Value: []byte(tt.cacheValue)}
 		if err := memcache.Set(nc, item); err != nil {
@@ -213,7 +213,7 @@ func TestCachedCertsCacheMiss(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	ec := NewContext(req)
+	ec := NewContext(req, nil, nil)
 
 	tts := []*struct {
 		respStatus                     int
@@ -430,5 +430,5 @@ func newContext(r *http.Request, factory func() Authenticator) context.Context {
 		AuthenticatorFactory = old
 	}(AuthenticatorFactory)
 	AuthenticatorFactory = factory
-	return NewContext(r)
+	return NewContext(r, nil, nil)
 }

--- a/endpoints/jwt_test.go
+++ b/endpoints/jwt_test.go
@@ -140,7 +140,7 @@ func TestVerifySignedJWT(t *testing.T) {
 		{"another.invalid.token", jwtValidTokenTime, nil},
 	}
 
-	ec := NewContext(r)
+	ec := NewContext(r, nil, nil)
 
 	for i, tt := range tts {
 		jwt, err := verifySignedJWT(ec, tt.token, tt.now.Unix())
@@ -183,7 +183,7 @@ func TestVerifyParsedToken(t *testing.T) {
 
 	r, _, closer := newTestRequest(t, "GET", "/", nil)
 	defer closer()
-	c := NewContext(r)
+	c := NewContext(r, nil, nil)
 
 	for i, tt := range tts {
 		jwt := signedJWT{
@@ -208,7 +208,7 @@ func TestCurrentIDTokenUser(t *testing.T) {
 
 	r, _, closer := newTestRequest(t, "GET", "/", nil)
 	defer closer()
-	c := NewContext(r)
+	c := NewContext(r, nil, nil)
 
 	aud := []string{jwtValidTokenObject.Audience, jwtValidTokenObject.ClientID}
 	azp := []string{jwtValidTokenObject.ClientID}


### PR DESCRIPTION
Adds an optional callback to Service that allows manipulation of the
Context that is passed to the method handler based on the
service/method, as well as preliminary request rejection.

Also adds accessor methods to pull the ServiceInfo and MethodInfo from
the handler's context.

This avoids the need to place boilerplate code at the beginning of each
method handler and enables unified Service-wide security and setup
operations.