### PR TITLE
Expose current service/method in the Context

### DIFF
--- a/endpoints/auth_test.go
+++ b/endpoints/auth_test.go
@@ -180,7 +180,7 @@ func TestCachedCertsCacheHit(t *testing.T) {
 	    	 "modulus": "123"} ]}`,
 			&certsList{[]*certInfo{{"RS256", "123", "some-id", "123"}}}},
 	}
-	ec := NewContext(req)
+	ec := NewContext(req, nil, nil)
 	for i, tt := range tts {
 		item := &memcache.Item{Key: DefaultCertURI, Value: []byte(tt.cacheValue)}
 		if err := memcache.Set(nc, item); err != nil {
@@ -213,7 +213,7 @@ func TestCachedCertsCacheMiss(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	ec := NewContext(req)
+	ec := NewContext(req, nil, nil)
 
 	tts := []*struct {
 		respStatus                     int
@@ -430,5 +430,5 @@ func newContext(r *http.Request, factory func() Authenticator) context.Context {
 		AuthenticatorFactory = old
 	}(AuthenticatorFactory)
 	AuthenticatorFactory = factory
-	return NewContext(r)
+	return NewContext(r, nil, nil)
 }

--- a/endpoints/jwt_test.go
+++ b/endpoints/jwt_test.go
@@ -140,7 +140,7 @@ func TestVerifySignedJWT(t *testing.T) {
 		{"another.invalid.token", jwtValidTokenTime, nil},
 	}
 
-	ec := NewContext(r)
+	ec := NewContext(r, nil, nil)
 
 	for i, tt := range tts {
 		jwt, err := verifySignedJWT(ec, tt.token, tt.now.Unix())
@@ -183,7 +183,7 @@ func TestVerifyParsedToken(t *testing.T) {
 
 	r, _, closer := newTestRequest(t, "GET", "/", nil)
 	defer closer()
-	c := NewContext(r)
+	c := NewContext(r, nil, nil)
 
 	for i, tt := range tts {
 		jwt := signedJWT{
@@ -208,7 +208,7 @@ func TestCurrentIDTokenUser(t *testing.T) {
 
 	r, _, closer := newTestRequest(t, "GET", "/", nil)
 	defer closer()
-	c := NewContext(r)
+	c := NewContext(r, nil, nil)
 
 	aud := []string{jwtValidTokenObject.Audience, jwtValidTokenObject.ClientID}
 	azp := []string{jwtValidTokenObject.ClientID}

--- a/endpoints/server.go
+++ b/endpoints/server.go
@@ -104,16 +104,6 @@ func (s *Server) HandleHTTP(mux *http.ServeMux) {
 
 // ServeHTTP is Server's implementation of http.Handler interface.
 func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
-	c := NewContext(r)
-	if s.ContextDecorator != nil {
-		ctx, err := s.ContextDecorator(c)
-		if err != nil {
-			writeError(w, err)
-			return
-		}
-		c = ctx
-	}
-
 	// Always respond with JSON, even when an error occurs.
 	// Note: API server doesn't expect an encoding in Content-Type header.
 	w.Header().Set("Content-Type", "application/json")
@@ -138,6 +128,17 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	if err != nil {
 		writeError(w, err)
 		return
+	}
+
+	// Generate the Context for this request.
+	c := NewContext(r, serviceSpec.info, methodSpec.info)
+	if s.ContextDecorator != nil {
+		ctx, err := s.ContextDecorator(c)
+		if err != nil {
+			writeError(w, err)
+			return
+		}
+		c = ctx
 	}
 
 	// Initialize RPC method request


### PR DESCRIPTION
Add EndpointInfo() method to pull the ServiceInfo and MethodInfo of the
current endpoint out of the Context.

Defer generation of the context to after the service/method have been
identified. This prevents unnecessary setup operations (including
AppEngine binding), until after the request is verified to be
referencing a valid endpoint.

This is a focused landing of the embedding portion of #125 built on top of #126 as requested.