### PR TITLE
Fix inconsistent handling of path names, required.

### DIFF
--- a/endpoints/service.go
+++ b/endpoints/service.go
@@ -277,8 +277,12 @@ func requiredParamNames(t reflect.Type) []string {
 			if field.PkgPath == "" {
 				parts := strings.Split(field.Tag.Get("endpoints"), ",")
 				for _, p := range parts {
-					if p == "required" {
-						params = append(params, field.Name)
+					if p == "required" || p == "req" {
+						name := fieldName(field)
+						if name == "" {
+							continue
+						}
+						params = append(params, name)
 						break
 					}
 				}


### PR DESCRIPTION
Use JSON-override name when constructing endpoints paths. Additionally,
accept both "req" and "required" endpoints struct tags to denote
required endpoints struct fields.

Fixes #132.