### PR TITLE
Sync hello world sample service name with README's one

### DIFF
--- a/samples/helloworld/helloworld.go
+++ b/samples/helloworld/helloworld.go
@@ -81,7 +81,7 @@ func (gs *GreetingService) Add(c context.Context, r *GreetingAddReq) error {
 
 func init() {
 	api, err := endpoints.RegisterService(&GreetingService{},
-		"greetings", "v1", "Greetings API", true)
+		"greeting", "v1", "Greetings API", true)
 	if err != nil {
 		log.Fatalf("Register service: %v", err)
 	}

--- a/samples/helloworld/static/greetings.js
+++ b/samples/helloworld/static/greetings.js
@@ -16,9 +16,9 @@ function GreetingsCtrl($scope, $http) {
   $scope.greetings = [];
   $scope.running = true;
   var api;
- 
+
   loadAPI(function() {
-    api = gapi.client.greetings;
+    api = gapi.client.greeting;
     // load the messages now and refresh every second after.
     $scope.refresh();
     window.setInterval($scope.refresh, 1000);
@@ -50,8 +50,8 @@ function loadAPI(then) {
 
   window.onAPILoaded = function() {
     var rootpath = "//" + window.location.host + "/_ah/api";
-    gapi.client.load('greetings', 'v1', then, rootpath);
-    window.onAPILoaded = undefined; 
+    gapi.client.load('greeting', 'v1', then, rootpath);
+    window.onAPILoaded = undefined;
   }
   script.src = 'https://apis.google.com/js/client.js?onload=onAPILoaded';
 


### PR DESCRIPTION
Though README uses singular `greeting` for service name, the hello world sample code uses plural `greetings`, it took me few minutes to figure out what's going on. It would be easier for newbies (like me me) to use the same service name both in README and the sample code. Thanks!
