### PR TITLE
Build failed in appengine/go sdk 1.9.35

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: go
 install:
-  - curl -sSo gae_sdk.zip https://storage.googleapis.com/appengine-sdks/featured/go_appengine_sdk_linux_amd64-1.9.24.zip
+  - curl -sSo gae_sdk.zip https://storage.googleapis.com/appengine-sdks/featured/go_appengine_sdk_linux_amd64-1.9.35.zip
   - unzip -q gae_sdk.zip
   - ./go_appengine/goapp get ./endpoints
 script:


### PR DESCRIPTION
https://cloud.google.com/appengine/docs/go/release-notes

> This release is based on Go 1.6.

Do you have plans for something updates?